### PR TITLE
Add support for setting brightness relative to the current value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lumix
 
-A simple, fast command-line tool for controlling monitor brightness on Windows. Designed for easy brightness management across multiple displays.
+A simple, fast command-line tool for controlling monitor brightness on Windows and Linux. Designed for easy brightness management across multiple displays.
 
 [![GitHub](https://img.shields.io/badge/github-Yrrrrrf%2Flumix-58A6FF?style=for-the-badge&logo=github)](https://github.com/Yrrrrrf/lumix)
 [![Crates.io](https://img.shields.io/crates/v/lumix.svg?style=for-the-badge&logo=rust)](https://crates.io/crates/lumix)
@@ -28,13 +28,15 @@ lumix get 12345  # Specific monitor brightness
 - Set brightness:
 ```bash
 lumix set 75  # All monitors to 75%
+lumix set 10+  # Increase all monitors by 10%
+lumix set 5-  # Decrease all monitors by 5%
 lumix set 12345 50  # Specific monitor to 50%
 ```
 
 ### Output Example
 
 ```
-Monitor 12345: 75% [0..=100] ██████████░░░░░░░░░░ 
+Monitor 12345: 75% [0..=100] ██████████░░░░░░░░░░
 ```
 
 Where:


### PR DESCRIPTION
Hey,

Thanks for this tool. I tried four things (ddcutil, monitorcontrol in python, wrapping ddcutil in python, and installing the monitorcontrol  rust tool) before finding this which just worked.

I really wanted to be be able to increase brightness by a set increment, and wanted something that could be easily installed on any machine. So I decided to add this this feature to the tool.

I don't really expect you to merge this - not quite sure it's worth your time - but I'm going to shove what I've done on github and maybe cargo so it's easy to install - so just notifying you. If you feel like merging / reimplementing this then I'll pull my code down since your tool will be a more standard tool that does what i want.

Thanks for your useful and functioning code - it forced me to learn a little rust.